### PR TITLE
Suggestion: Expose measure names

### DIFF
--- a/src/main/java/io/moderne/devcenter/JUnitUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/JUnitUpgrade.java
@@ -16,14 +16,19 @@
 package io.moderne.devcenter;
 
 import io.moderne.devcenter.table.UpgradesAndMigrations;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.tree.J;
 
-public class JUnitUpgrade extends Recipe {
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JUnitUpgrade extends UpgradeRecipe {
     private final transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Override
@@ -47,10 +52,10 @@ public class JUnitUpgrade extends Recipe {
                         .getVisitor().visitNonNull(tree, ctx);
                 if (tree != j2) {
                     upgradesAndMigrations.insertRow(ctx, new UpgradesAndMigrations.Row(
-                            "Move to JUnit 5",
+                            getInstanceName(),
                             Measure.JUnit4.ordinal(),
-                            "JUnit 4",
-                            "JUnit 4"
+                            Measure.JUnit4.getDisplayName(),
+                            Measure.JUnit4.getMinimumVersionName()
                     ));
                 }
 
@@ -60,8 +65,8 @@ public class JUnitUpgrade extends Recipe {
                     upgradesAndMigrations.insertRow(ctx, new UpgradesAndMigrations.Row(
                             getInstanceName(),
                             Measure.Completed.ordinal(),
-                            "Completed",
-                            "JUnit 5"
+                            Measure.Completed.getDisplayName(),
+                            Measure.Completed.getMinimumVersionName()
                     ));
                 }
 
@@ -70,8 +75,19 @@ public class JUnitUpgrade extends Recipe {
         };
     }
 
+    @Override
+    public List<String> measureNames() {
+        return Arrays.stream(Measure.values())
+                .map(Measure::getDisplayName)
+                .collect(Collectors.toList());
+    }
+
+    @RequiredArgsConstructor
+    @Getter
     public enum Measure {
-        JUnit4,
-        Completed
+        JUnit4("JUnit 4", "JUnit 4"),
+        Completed("Completed", "JUnit 5");
+        final String displayName;
+        final String minimumVersionName;
     }
 }

--- a/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
@@ -22,15 +22,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
-import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.tree.J;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class JavaVersionUpgrade extends Recipe {
+public class JavaVersionUpgrade extends UpgradeRecipe {
     transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Option(displayName = "Major version",
@@ -87,6 +90,13 @@ public class JavaVersionUpgrade extends Recipe {
                 return tree;
             }
         };
+    }
+
+    @Override
+    public List<String> measureNames() {
+        return Arrays.stream(Measure.values())
+                .map(Measure::getDisplayName)
+                .collect(Collectors.toList());
     }
 
     @Getter

--- a/src/main/java/io/moderne/devcenter/LibraryUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/LibraryUpgrade.java
@@ -29,13 +29,16 @@ import org.openrewrite.maven.table.DependenciesInUse;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class LibraryUpgrade extends Recipe {
+public class LibraryUpgrade extends UpgradeRecipe {
     transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Option(displayName = "Card name",
@@ -98,11 +101,18 @@ public class LibraryUpgrade extends Recipe {
         });
     }
 
+    @Override
+    public List<String> measureNames() {
+        return Arrays.stream(Measure.values())
+                .map(Measure::toString)
+                .collect(Collectors.toList());
+    }
+
     public enum Measure {
         Major,
         Minor,
         Patch,
-        Completed
+        Completed;
     }
 
     private static class UpgradeRowBuilder {

--- a/src/main/java/io/moderne/devcenter/UpgradeRecipe.java
+++ b/src/main/java/io/moderne/devcenter/UpgradeRecipe.java
@@ -1,0 +1,25 @@
+package io.moderne.devcenter;
+
+import org.openrewrite.Recipe;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class UpgradeRecipe extends Recipe {
+
+    /**
+     * Returns an ordered list of the measures used by this recipe.
+     * These are the names used in the `value` column in the data table. The measure names will be exposed as tags on the recipe to allow
+     * showing any measures with 0 results in the DevCenter UI.
+     */
+    public abstract List<String> measureNames();
+
+    @Override
+    public Set<String> getTags() {
+        return measureNames().stream()
+                .map(measure -> "DevCenter:measure:" + measure)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}


### PR DESCRIPTION
Adds an interface for upgrade recipes that automatically exposes measure names as tags. These tags can then (if available) be used to show measures with 0 results on the DevCenter UI.
