### PR TITLE
Make `DevCenterMeasurer` a non-generic interface to avoid class loading issues when reading measures in CLI

### DIFF
--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -61,7 +61,7 @@ public class DevCenter {
         for (Recipe subRecipe : recipe.getRecipeList()) {
             String fixRecipe = fixRecipe(subRecipe.getDescriptor());
             if (fixRecipe != null) {
-                DevCenterMeasurer<?> devCenterMeasurer = findDevCenterCardRecursive(subRecipe);
+                DevCenterMeasurer devCenterMeasurer = findDevCenterCardRecursive(subRecipe);
                 if (devCenterMeasurer != null) {
                     upgradesAndMigrations.add(new UpgradeOrMigration(
                             recipe.getDisplayName(),
@@ -76,12 +76,12 @@ public class DevCenter {
         return upgradesAndMigrations;
     }
 
-    private @Nullable DevCenterMeasurer<?> findDevCenterCardRecursive(Recipe recipe) {
+    private @Nullable DevCenterMeasurer findDevCenterCardRecursive(Recipe recipe) {
         for (Recipe subRecipe : recipe.getRecipeList()) {
             if (subRecipe instanceof DevCenterMeasurer) {
-                return (DevCenterMeasurer<?>) subRecipe;
+                return (DevCenterMeasurer) subRecipe;
             }
-            DevCenterMeasurer<?> devCenterMeasurer = findDevCenterCardRecursive(subRecipe);
+            DevCenterMeasurer devCenterMeasurer = findDevCenterCardRecursive(subRecipe);
             if (devCenterMeasurer != null) {
                 return devCenterMeasurer;
             }
@@ -121,7 +121,7 @@ public class DevCenter {
         String displayName;
         String recipeId;
         String fixRecipeId;
-        DevCenterMeasurer<?> card;
+        DevCenterMeasurer card;
     }
 
     @Value

--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -64,10 +64,10 @@ public class DevCenter {
                 DevCenterMeasurer devCenterMeasurer = findDevCenterCardRecursive(subRecipe);
                 if (devCenterMeasurer != null) {
                     upgradesAndMigrations.add(new UpgradeOrMigration(
-                            recipe.getDisplayName(),
+                            devCenterMeasurer.getInstanceName(),
                             recipe.getName(),
                             fixRecipe,
-                            devCenterMeasurer
+                            devCenterMeasurer.getMeasures()
                     ));
                 }
             }
@@ -121,7 +121,7 @@ public class DevCenter {
         String displayName;
         String recipeId;
         String fixRecipeId;
-        DevCenterMeasurer card;
+        List<String> measures;
     }
 
     @Value

--- a/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
+++ b/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
@@ -18,5 +18,7 @@ package io.moderne.devcenter;
 import java.util.List;
 
 public interface DevCenterMeasurer {
+    String getInstanceName();
+
     List<String> getMeasures();
 }

--- a/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
+++ b/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
@@ -15,34 +15,8 @@
  */
 package io.moderne.devcenter;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-public interface DevCenterMeasurer<Measures extends Enum<?> & DevCenterMeasure> {
-    default List<String> getMeasures() {
-        Measures[] values = null;
-        for (Type generic : getClass().getGenericInterfaces()) {
-            if (generic instanceof ParameterizedType) {
-                ParameterizedType pt = (ParameterizedType) generic;
-                if (pt.getRawType().equals(DevCenterMeasurer.class)) {
-                    Type actualTypeArgument = pt.getActualTypeArguments()[0];
-                    //noinspection unchecked
-                    values = (Measures[]) ((Class<Enum<?>>) actualTypeArgument).getEnumConstants();
-                }
-            }
-        }
-        if (values == null) {
-            return Collections.emptyList();
-        }
-
-        List<String> names = new ArrayList<>();
-        for (Measures value : values) {
-            names.add(value.getDisplayName());
-        }
-
-        return names;
-    }
+public interface DevCenterMeasurer {
+    List<String> getMeasures();
 }

--- a/src/main/java/io/moderne/devcenter/JUnitUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/JUnitUpgrade.java
@@ -23,7 +23,11 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.tree.J;
 
-public class JUnitUpgrade extends Recipe implements DevCenterMeasurer<JUnitUpgrade.Measure> {
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JUnitUpgrade extends Recipe implements DevCenterMeasurer {
     private final transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Override
@@ -68,6 +72,11 @@ public class JUnitUpgrade extends Recipe implements DevCenterMeasurer<JUnitUpgra
                 return j3;
             }
         };
+    }
+
+    @Override
+    public List<String> getMeasures() {
+        return Stream.of(Measure.values()).map(Measure::name).collect(Collectors.toList());
     }
 
     public enum Measure implements DevCenterMeasure {

--- a/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
@@ -28,9 +28,13 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.tree.J;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class JavaVersionUpgrade extends Recipe implements DevCenterMeasurer<JavaVersionUpgrade.Measure> {
+public class JavaVersionUpgrade extends Recipe implements DevCenterMeasurer {
     transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Option(displayName = "Major version",
@@ -87,6 +91,11 @@ public class JavaVersionUpgrade extends Recipe implements DevCenterMeasurer<Java
                 return tree;
             }
         };
+    }
+
+    @Override
+    public List<String> getMeasures() {
+        return Stream.of(Measure.values()).map(Measure::getDisplayName).collect(Collectors.toList());
     }
 
     @Getter

--- a/src/main/java/io/moderne/devcenter/LibraryUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/LibraryUpgrade.java
@@ -30,12 +30,14 @@ import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class LibraryUpgrade extends Recipe implements DevCenterMeasurer<LibraryUpgrade.Measure> {
+public class LibraryUpgrade extends Recipe implements DevCenterMeasurer {
     transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
 
     @Option(displayName = "Card name",
@@ -96,6 +98,11 @@ public class LibraryUpgrade extends Recipe implements DevCenterMeasurer<LibraryU
                 return t;
             }
         });
+    }
+
+    @Override
+    public List<String> getMeasures() {
+        return Stream.of(Measure.values()).map(Measure::name).collect(Collectors.toList());
     }
 
     public enum Measure implements DevCenterMeasure {

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -35,7 +35,7 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
     @Language("markdown")
     public final static String DISPLAY_NAME = "Upgrades and migrations";
 
-    public <T extends Recipe & DevCenterMeasurer<?>> UpgradesAndMigrations(T recipe) {
+    public <T extends Recipe & DevCenterMeasurer> UpgradesAndMigrations(T recipe) {
         super(recipe, DISPLAY_NAME, "Progress towards organizational objectives on library or language migrations and upgrades.");
     }
 

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -51,7 +51,7 @@ public class DevCenterTest implements RewriteTest {
 
         assertThat(devCenter.getUpgradesAndMigrations()).hasSize(3);
         assertThat(devCenter.getUpgradesAndMigrations().stream()
-          .map(u -> u.getCard().getMeasures()))
+          .map(DevCenter.UpgradeOrMigration::getMeasures))
           .contains(List.of("Major", "Minor", "Patch", "Completed"));
 
         assertThat(devCenter.getSecurity()).isNotNull();


### PR DESCRIPTION
- reduced `DevCenterMeasurer` to a simple interface containing a non-default `List<String> getMeasures` and `String getInstanceName` methods. This addresses a issue in the CLI which prevented it from fetching upgrade and migration recipes using `DevCenter#getUpgradesAndMigrations`
- replaced `DevCenter.UpgradeOrMigration.card` field with `measures` to match `DevCenter.Security`