### PR TITLE
Security recipeId should have the ID not display name.

### DIFF
--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -102,7 +102,7 @@ public class DevCenter {
         for (String tag : recipe.getTags()) {
             if (tag.startsWith("DevCenter:security")) {
                 allSecurity.add(new Security(
-                        recipe.getDisplayName(),
+                        recipe.getName(),
                         recipe.getRecipeList().stream().map(Recipe::getInstanceName).collect(Collectors.toList())));
             }
         }


### PR DESCRIPTION
This is needed to use the Security parent/fix recipe to run all the security fixes at once.
