### PR TITLE
Use the `DevCenterMeasurer` instanceName as the `Card.displayName`

### DIFF
--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -80,8 +80,8 @@ public class DevCenter {
             DevCenterMeasurer devCenterMeasurer = findDevCenterCardRecursive(recipe);
             if (devCenterMeasurer != null && hasUpgradesAndMigrations(recipe)) {
                 upgradesAndMigrations.add(new Card(
-                        recipe.getInstanceName(),
-                        recipe.getName(),
+                        devCenterMeasurer.getInstanceName(),
+                        devCenterMeasurer.getName(),
                         fixRecipe,
                         devCenterMeasurer.getMeasures()));
             }

--- a/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
+++ b/src/main/java/io/moderne/devcenter/DevCenterMeasurer.java
@@ -19,4 +19,8 @@ import java.util.List;
 
 public interface DevCenterMeasurer {
     List<String> getMeasures();
+
+    String getName();
+
+    String getInstanceName();
 }

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -71,9 +71,14 @@ public class DevCenterTest implements RewriteTest {
         devCenter.validate();
 
         assertThat(devCenter.getUpgradesAndMigrations()).hasSize(3);
-        assertThat(devCenter.getUpgradesAndMigrations().stream()
-          .map(DevCenter.Card::getMeasures))
-          .contains(List.of("Major", "Minor", "Patch", "Completed"));
+        assertThat(devCenter.getUpgradesAndMigrations())
+          .extracting(DevCenter.Card::getDisplayName)
+          .contains("Move to Java 21");
+        assertThat(devCenter.getUpgradesAndMigrations())
+          .extracting(DevCenter.Card::getMeasures)
+          .contains(
+            List.of("Major", "Minor", "Patch", "Completed")
+          );
 
         assertThat(devCenter.getSecurity()).isNotNull();
         assertThat(devCenter.getSecurity().getMeasures())


### PR DESCRIPTION
We expect the card name to be the same in the data-table as on the DevCenter Card objects. Otherwise we cannot match them
