### PR TITLE
Use FQN check instead of instanceof to avoid parent classloading of `UpgradeMigrationCard` and `ReportAsSecurityIssues`

### DIFF
--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -120,7 +120,7 @@ public class DevCenter {
     }
 
     private List<Card> getUpgradesAndMigrationsRecursive(Recipe recipe, List<Card> upgradesAndMigrations) {
-        if (recipe instanceof UpgradeMigrationCard) {
+        if (instanceOfByFqn(recipe.getClass(), UpgradeMigrationCard.class)) {
             upgradesAndMigrations.add(new Card(
                     recipe.getInstanceName(),
                     recipe.getDescription(),
@@ -136,7 +136,7 @@ public class DevCenter {
 
     private List<Card> getSecurityRecursive(Recipe recipe, List<Card> allSecurity) {
         for (Recipe subRecipe : recipe.getRecipeList()) {
-            if (subRecipe instanceof ReportAsSecurityIssues) {
+            if (instanceOfByFqn(subRecipe.getClass(), ReportAsSecurityIssues.class)) {
                 List<DevCenterMeasure> measures = new ArrayList<>();
                 List<Recipe> recipeList = recipe.getRecipeList();
                 for (int i = 0; i < recipeList.size(); i++) {
@@ -197,5 +197,15 @@ public class DevCenter {
     public enum Aggregation {
         PER_OCCURRENCE,
         PER_REPOSITORY
+    }
+
+    private boolean instanceOfByFqn(@Nullable Class<?> current, Class<?> expected) {
+        if (current == null) {
+            return false;
+        }
+        if (current.getName().equals(expected.getName())) {
+            return true;
+        }
+        return instanceOfByFqn(current.getSuperclass(), expected);
     }
 }

--- a/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
+++ b/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
@@ -15,13 +15,13 @@
  */
 package io.moderne.devcenter.result;
 
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
 import io.moderne.devcenter.DevCenter;
 import io.moderne.organizations.Organization;
 import io.moderne.organizations.RepositoryId;
 import io.moderne.organizations.RepositorySpec;
 import lombok.RequiredArgsConstructor;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
 

--- a/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
+++ b/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
@@ -38,9 +38,9 @@ class SecurityIssuesReader {
     private final DevCenter devCenter;
     private final Map<RepositoryId, List<Organization<RepositoryResult>>> repositoryMap;
 
-    public void read(Reader upgradesAndMigrations) {
+    public void read(Reader securitiesIssues) {
         try (Csv.Reader csv = Csv.Reader.of(Csv.Format.DEFAULT, Csv.ReaderOptions.builder()
-                .lenientSeparator(true).build(), upgradesAndMigrations)) {
+                .lenientSeparator(true).build(), securitiesIssues)) {
 
             List<SecurityIssuesColumn> headers = null;
             while (csv.readLine()) {

--- a/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
+++ b/src/main/java/io/moderne/devcenter/result/SecurityIssuesReader.java
@@ -40,12 +40,12 @@ class SecurityIssuesReader {
     private final DevCenter devCenter;
     private final Map<RepositoryId, List<Organization<RepositoryResult>>> repositoryMap;
 
-    public void read(Reader securitiesIssues) {
+    public void read(Reader securityIssues) {
         CsvParserSettings settings = new CsvParserSettings();
         settings.setLineSeparatorDetectionEnabled(true);
 
         CsvParser parser = new CsvParser(settings);
-        parser.beginParsing(securitiesIssues);
+        parser.beginParsing(securityIssues);
 
         try {
             List<SecurityIssuesColumn> headers = null;


### PR DESCRIPTION
instanceof does not work across classloaders, which is why we normally parent classload such classes. However, these are implementations/extensions of recipe and we do not want to parent classload these.

Instead we just use the FQN and compare those (recursively) to find instances of the recipes.
