### PR TITLE
Pin organizations-format to be able to build & release for a CLI patch release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     // Only needed for result parsing (package io.moderne.devcenter.result),
     // not for defining and running DevCenter recipes.
-    compileOnly("io.moderne:moderne-organizations-format:latest.release")
+    compileOnly("io.moderne:moderne-organizations-format:0.12.0")
     implementation("com.univocity:univocity-parsers:latest.release")
 
     implementation("org.openrewrite:rewrite-java:${rewriteVersion}")
@@ -24,7 +24,7 @@ dependencies {
 
     implementation("org.slf4j:slf4j-api:1.7.+")
 
-    testImplementation("io.moderne:moderne-organizations-format:latest.release")
+    testImplementation("io.moderne:moderne-organizations-format:0.12.0")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-21:${rewriteVersion}")
     testRuntimeOnly("junit:junit:4.+")


### PR DESCRIPTION
required because the latest organizations-format has made a change where the assumptions in rewrite-devcenter no longer apply (epsilon is always the root).