### PR TITLE
Do not return measures above the major version. for JavaVersionUpgrade

### DIFF
--- a/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java
@@ -28,8 +28,9 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.tree.J;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -95,7 +96,9 @@ public class JavaVersionUpgrade extends UpgradeMigrationCard {
 
     @Override
     public List<DevCenterMeasure> getMeasures() {
-        return Arrays.asList(Measure.values());
+        return Stream.of(Measure.values())
+                .filter(measure -> measure.minimumMajorVersion < majorVersion)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -106,13 +109,14 @@ public class JavaVersionUpgrade extends UpgradeMigrationCard {
     @Getter
     @RequiredArgsConstructor
     public enum Measure implements DevCenterMeasure {
-        Java8Plus("Java 8+", "Technically, this is any version less than 11."),
-        Java11Plus("Java 11+", "Java 11 and later"),
-        Java17Plus("Java 17+", "Java 17 and later"),
-        Java21Plus("Java 21+", "Java 21 and later"),
-        Completed("Completed", "The upgrade to the desired Java version is already complete.");
+        Java8Plus("Java 8+", "Technically, this is any version less than 11.", 8),
+        Java11Plus("Java 11+", "Java 11 and later", 11),
+        Java17Plus("Java 17+", "Java 17 and later", 17),
+        Java21Plus("Java 21+", "Java 21 and later", 21),
+        Completed("Completed", "The upgrade to the desired Java version is already complete.", 0);
 
         private final @Language("markdown") String name;
         private final @Language("markdown") String description;
+        private final int minimumMajorVersion;
     }
 }

--- a/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
+++ b/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
 import java.util.stream.Stream;
 
-import static io.moderne.devcenter.JavaVersionUpgrade.Measure.Completed;
-import static io.moderne.devcenter.JavaVersionUpgrade.Measure.Java8Plus;
+import static io.moderne.devcenter.JavaVersionUpgrade.Measure.*;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
@@ -57,5 +57,23 @@ class JavaVersionUpgradeTest implements RewriteTest {
             actualVersion
           )
         );
+    }
+
+    private static Stream<Arguments> versionAndMeasures() {
+        return Stream.of(
+          Arguments.of(8, List.of(Completed)),
+          Arguments.of(11, List.of(Java8Plus, Completed)),
+          Arguments.of(17, List.of(Java8Plus, Java11Plus, Completed)),
+          Arguments.of(18, List.of(Java8Plus, Java11Plus, Java17Plus, Completed)),
+          Arguments.of(21, List.of(Java8Plus, Java11Plus, Java17Plus, Completed)),
+          Arguments.of(24, List.of(Java8Plus, Java11Plus, Java17Plus, Java21Plus, Completed))
+        );
+    }
+
+    @MethodSource("versionAndMeasures")
+    @ParameterizedTest
+    void measuresShouldNotIncludeTargetVersionOrAbove(int targetVersion, List<JavaVersionUpgrade.Measure> expectedMeasures) {
+        assertThat(new JavaVersionUpgrade(targetVersion, null).getMeasures())
+          .containsExactlyElementsOf(expectedMeasures);
     }
 }


### PR DESCRIPTION
When updating to java 21 we do not want to expose the `Java21Plus` measure. Otherwise that will show up as 0% always but the actual java 21 repos will be counted under `Completed`
