### PR TITLE
Adjust ordinal to be non-sparse

### DIFF
--- a/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
+++ b/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
@@ -27,4 +27,8 @@ public abstract class UpgradeMigrationCard extends Recipe {
     public abstract List<DevCenterMeasure> getMeasures();
 
     public abstract @Nullable String getFixRecipeId();
+
+    public int ordinal(DevCenterMeasure measure) {
+        return getMeasures().indexOf(measure);
+    }
 }

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -22,7 +22,6 @@ import org.intellij.lang.annotations.Language;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.scheduling.RecipeRunCycle;
 import org.openrewrite.semver.LatestRelease;
 
 import java.util.ArrayList;
@@ -40,13 +39,12 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
         super(recipe, DISPLAY_NAME, "Progress towards organizational objectives on library or language migrations and upgrades.");
     }
 
-    public <E extends Enum<E> & DevCenterMeasure> void insertRow(ExecutionContext ctx,
-                                                                 UpgradeMigrationCard recipe,
-                                                                 E measure, String currentMinimumVersion) {
-        RecipeRunCycle<?> cycle = ctx.getCycleDetails();
+    public <E extends DevCenterMeasure> void insertRow(ExecutionContext ctx,
+                                                       UpgradeMigrationCard recipe,
+                                                       E measure, String currentMinimumVersion) {
         insertRow(ctx, new UpgradesAndMigrations.Row(
                 recipe.getInstanceName(),
-                measure.ordinal(),
+                recipe.ordinal(measure),
                 measure.getName(),
                 currentMinimumVersion
         ));

--- a/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
+++ b/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
@@ -73,7 +73,9 @@ class JavaVersionUpgradeTest implements RewriteTest {
 
     @MethodSource("versionAndMeasures")
     @ParameterizedTest
-    void measuresShouldNotIncludeTargetVersionOrAbove(int targetVersion, List<JavaVersionUpgrade.Measure> expectedMeasures, int expectedCompletedOrdinal) {
+    void measuresShouldNotIncludeTargetVersionOrAbove(int targetVersion,
+                                                      List<JavaVersionUpgrade.Measure> expectedMeasures,
+                                                      int expectedCompletedOrdinal) {
         UpgradeMigrationCard recipe = new JavaVersionUpgrade(targetVersion, null);
         assertThat(recipe.getMeasures())
           .containsExactlyElementsOf(expectedMeasures);

--- a/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
+++ b/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
@@ -62,19 +62,22 @@ class JavaVersionUpgradeTest implements RewriteTest {
 
     private static Stream<Arguments> versionAndMeasures() {
         return Stream.of(
-          Arguments.of(8, List.of(Completed)),
-          Arguments.of(11, List.of(Java8Plus, Completed)),
-          Arguments.of(17, List.of(Java8Plus, Java11Plus, Completed)),
-          Arguments.of(18, List.of(Java8Plus, Java11Plus, Java17Plus, Completed)),
-          Arguments.of(21, List.of(Java8Plus, Java11Plus, Java17Plus, Completed)),
-          Arguments.of(24, List.of(Java8Plus, Java11Plus, Java17Plus, Java21Plus, Completed))
+          Arguments.of(8, List.of(Completed), 0),
+          Arguments.of(11, List.of(Java8Plus, Completed), 1),
+          Arguments.of(17, List.of(Java8Plus, Java11Plus, Completed), 2),
+          Arguments.of(18, List.of(Java8Plus, Java11Plus, Java17Plus, Completed), 3),
+          Arguments.of(21, List.of(Java8Plus, Java11Plus, Java17Plus, Completed), 3),
+          Arguments.of(24, List.of(Java8Plus, Java11Plus, Java17Plus, Java21Plus, Completed), 4)
         );
     }
 
     @MethodSource("versionAndMeasures")
     @ParameterizedTest
-    void measuresShouldNotIncludeTargetVersionOrAbove(int targetVersion, List<JavaVersionUpgrade.Measure> expectedMeasures) {
-        assertThat(new JavaVersionUpgrade(targetVersion, null).getMeasures())
+    void measuresShouldNotIncludeTargetVersionOrAbove(int targetVersion, List<JavaVersionUpgrade.Measure> expectedMeasures, int expectedCompletedOrdinal) {
+        UpgradeMigrationCard recipe = new JavaVersionUpgrade(targetVersion, null);
+        assertThat(recipe.getMeasures())
           .containsExactlyElementsOf(expectedMeasures);
+
+        assertThat(recipe.ordinal(JavaVersionUpgrade.Measure.Completed)).isEqualTo(expectedCompletedOrdinal);
     }
 }

--- a/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
+++ b/src/test/java/io/moderne/devcenter/JavaVersionUpgradeTest.java
@@ -43,13 +43,14 @@ class JavaVersionUpgradeTest implements RewriteTest {
     @MethodSource("javaVersions")
     @ParameterizedTest
     void java8(int targetVersion, int actualVersion, JavaVersionUpgrade.Measure measure) {
+        UpgradeMigrationCard recipe = new JavaVersionUpgrade(targetVersion, null);
         rewriteRun(
           spec -> spec
-            .recipe(new JavaVersionUpgrade(targetVersion, null))
+            .recipe(recipe)
             .dataTable(UpgradesAndMigrations.Row.class, rows ->
               assertThat(rows).containsExactly(
                 new UpgradesAndMigrations.Row("Move to Java " + targetVersion,
-                  measure.ordinal(), measure.getName(), Integer.toString(actualVersion))
+                  recipe.ordinal(measure), measure.getName(), Integer.toString(actualVersion))
               )),
           version(
             //language=java


### PR DESCRIPTION
Problem

  The `JavaVersionUpgrade` recipe was experiencing an `IndexOutOfBoundsException` when the `Completed` measure was being listed with ordinal 4, but only 4 measures existed in the total filtered list (0-3 indices). This occurred because the enum's natural ordinal() method didn't account for filtered measures returned by `getMeasures()`.

Solution:

Calculate the ordinal by finding the index of a measure in the list of filtered measures instead of using the enum's ordinal value (which cannot be changed during runtime).

Solves:

```
Caused by: java.lang.IndexOutOfBoundsException: Index 4 out of bounds for length 4
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:361)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at io.moderne.devcenter.result.UpgradesAndMigrationsReader.read(UpgradesAndMigrationsReader.java:110)
```
