### PR TITLE
Do not assume `org.openrewrite.dataTables` messages preserve order in `DataTableWatcher`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     testImplementation("io.moderne:moderne-organizations-format:latest.release")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-21:${rewriteVersion}")
+    testImplementation(gradleApi())
+    testImplementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
     testRuntimeOnly("junit:junit:4.+")
 }
 

--- a/src/main/java/io/moderne/devcenter/internal/DataTableRowWatcher.java
+++ b/src/main/java/io/moderne/devcenter/internal/DataTableRowWatcher.java
@@ -29,16 +29,16 @@ import static java.util.Collections.emptyMap;
 public class DataTableRowWatcher<Row> {
     private final DataTable<Row> dataTable;
     private final ExecutionContext ctx;
-
-    int startingRowCount;
+    private List<Row> startingRows;
 
     public void start() {
-        startingRowCount = getRows().size();
+        startingRows = getRows();
     }
 
     public List<Row> stop() {
         List<Row> rows = getRows();
-        return rows.subList(startingRowCount, rows.size());
+        rows.removeAll(startingRows);
+        return rows;
     }
 
     private List<Row> getRows() {

--- a/src/main/java/io/moderne/devcenter/internal/DataTableRowWatcher.java
+++ b/src/main/java/io/moderne/devcenter/internal/DataTableRowWatcher.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.openrewrite.DataTable;
 import org.openrewrite.ExecutionContext;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +44,7 @@ public class DataTableRowWatcher<Row> {
     private List<Row> getRows() {
         Map<DataTable<?>, List<?>> dataTables = ctx.getMessage("org.openrewrite.dataTables", emptyMap());
         // TODO because two DataTable of the same type can be created
-        List<Row> rows = new ArrayList<>();
+        List<Row> rows = new LinkedList<>();
         for (Map.Entry<DataTable<?>, List<?>> dataTableEntry : dataTables.entrySet()) {
             if (dataTableEntry.getKey().getClass().equals(dataTable.getClass())) {
                 //noinspection unchecked

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -25,9 +25,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.semver.LatestRelease;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.openrewrite.ExecutionContext.CURRENT_CYCLE;
 
@@ -54,7 +55,7 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
     public void insertRow(ExecutionContext ctx, Row row) {
         // TODO CURRENT_CYCLE value is null in the context of a RewriteTest.
         if (ctx.getMessage(CURRENT_CYCLE) == null || this.allowWritingInThisCycle(ctx)) {
-            ctx.computeMessage("org.openrewrite.dataTables", row, ConcurrentHashMap<DataTable<?>, List<?>>::new, (extract, allDataTables) -> {
+            ctx.computeMessage("org.openrewrite.dataTables", row, () -> Collections.synchronizedMap(new LinkedHashMap<DataTable<?>, List<?>>()), (extract, allDataTables) -> {
                 List<Row> rows = getRows(allDataTables);
                 int minOrdinal = rows.stream()
                         .filter(r -> r.getCard().equals(row.getCard()))

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -75,7 +75,6 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
                         rows.add(row);
                     }
                 }
-
                 return allDataTables;
             });
         }

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -25,10 +25,9 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.semver.LatestRelease;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.openrewrite.ExecutionContext.CURRENT_CYCLE;
 
@@ -55,7 +54,7 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
     public void insertRow(ExecutionContext ctx, Row row) {
         // TODO CURRENT_CYCLE value is null in the context of a RewriteTest.
         if (ctx.getMessage(CURRENT_CYCLE) == null || this.allowWritingInThisCycle(ctx)) {
-            ctx.computeMessage("org.openrewrite.dataTables", row, () -> Collections.synchronizedMap(new LinkedHashMap<DataTable<?>, List<?>>()), (extract, allDataTables) -> {
+            ctx.computeMessage("org.openrewrite.dataTables", row, ConcurrentHashMap<DataTable<?>, List<?>>::new, (extract, allDataTables) -> {
                 List<Row> rows = getRows(allDataTables);
                 int minOrdinal = rows.stream()
                         .filter(r -> r.getCard().equals(row.getCard()))
@@ -76,6 +75,7 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
                         rows.add(row);
                     }
                 }
+
                 return allDataTables;
             });
         }

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -36,7 +36,9 @@ import java.util.stream.Stream;
 
 import static io.moderne.devcenter.JUnitJupiterUpgrade.Measure.JUnit4;
 import static io.moderne.devcenter.JavaVersionUpgrade.Measure.Java8Plus;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.java;
@@ -268,14 +270,12 @@ class DevCenterTest implements RewriteTest {
           spec ->
             spec.recipeFromYaml(recipe, "io.moderne.devcenter.TwoLibraryUpgrades")
               .beforeRecipe(withToolingApi())
-              .afterRecipe(after -> {
-                  assertThat(after.getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations"))
-                    .extracting("card", "ordinal", "value", "currentMinimumVersion")
-                    .containsExactly(
-                      tuple("Move to Spring Boot 3.5.0", 0, "Major", "2.7.18"),
-                      tuple("Move to commons collections 3.2.2", 0, "Major", "2.0")
-                    );
-              }),
+              .afterRecipe(after -> assertThat(after.getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations"))
+                .extracting("card", "ordinal", "value", "currentMinimumVersion")
+                .containsExactly(
+                  tuple("Move to Spring Boot 3.5.0", 0, "Major", "2.7.18"),
+                  tuple("Move to commons collections 3.2.2", 0, "Major", "2.0")
+                )),
           //language=Groovy
           buildGradle(
             """

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -16,6 +16,7 @@
 package io.moderne.devcenter;
 
 import io.moderne.devcenter.table.UpgradesAndMigrations;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,8 +36,9 @@ import java.util.stream.Stream;
 
 import static io.moderne.devcenter.JUnitJupiterUpgrade.Measure.JUnit4;
 import static io.moderne.devcenter.JavaVersionUpgrade.Measure.Java8Plus;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 
@@ -199,7 +201,7 @@ class DevCenterTest implements RewriteTest {
                 // Load io.moderne.devcenter classes (including UpgradeMigrationCard) in this classloader
                 // to ensure they are different from the ones in the test classloader
                 if (name.startsWith("io.moderne.devcenter.") &&
-                    !name.startsWith("io.moderne.devcenter.DevCenter")) {
+                  !name.startsWith("io.moderne.devcenter.DevCenter")) {
                     // Get the resource path for the class
                     String resourcePath = name.replace('.', '/') + ".class";
                     try (var inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
@@ -231,7 +233,7 @@ class DevCenterTest implements RewriteTest {
               @Override
               public String getDescription() {
                   return "Simulates `DeclarativeRecipe`, which is parent loaded and contains " +
-                         "child loaded sub-recipes.";
+                    "child loaded sub-recipes.";
               }
 
               @Override
@@ -239,6 +241,72 @@ class DevCenterTest implements RewriteTest {
                   return List.of(recipe);
               }
           })
+        );
+    }
+
+    @Test
+    void devcenterWithMultipleLibraryUpgradeRecipesHasCorrectData() {
+        @Language("yaml") String recipe = """
+          type: specs.openrewrite.org/v1beta/recipe
+          name: io.moderne.devcenter.TwoLibraryUpgrades
+          displayName: Starter DevCenter library version upgrade card
+          description: Upgrade library versions.
+          recipeList:
+            - io.moderne.devcenter.LibraryUpgrade:
+                cardName: Move to Spring Boot 3.5.0
+                groupIdPattern: org.springframework.boot
+                artifactIdPattern: '*'
+                version: 3.5.0
+                upgradeRecipe: io.moderne.java.spring.boot3.UpgradeSpringBoot_3_5
+            - io.moderne.devcenter.LibraryUpgrade:
+                cardName: Move to commons collections 3.2.2
+                groupIdPattern: commons-collections
+                artifactIdPattern: commons-collections
+                version: 3.2.2
+          """;
+        rewriteRun(
+          spec ->
+            spec.recipeFromYaml(recipe, "io.moderne.devcenter.TwoLibraryUpgrades")
+              .beforeRecipe(withToolingApi())
+              .afterRecipe(after -> {
+                  assertThat(after.getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations"))
+                    .extracting("card", "ordinal", "value", "currentMinimumVersion")
+                    .containsExactly(
+                      tuple("Move to Spring Boot 3.5.0", 0, "Major", "2.7.18"),
+                      tuple("Move to commons collections 3.2.2", 0, "Major", "2.0")
+                    );
+              }),
+          //language=Groovy
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id 'org.springframework.boot' version '2.7.18'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation "org.springframework.boot:spring-boot-starter-web"
+                  implementation "commons-collections:commons-collections:2.0"
+              }
+              """,
+            """
+            plugins {
+                id "java"
+                id 'org.springframework.boot' version '2.7.18'
+                id 'io.spring.dependency-management' version '1.1.7'
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                /*~~(org.springframework.boot:spring-boot:2.7.18,org.springframework.boot:spring-boot-autoconfigure:2.7.18,org.springframework.boot:spring-boot-starter-logging:2.7.18,org.springframework.boot:spring-boot-starter-web:2.7.18,org.springframework.boot:spring-boot-starter:2.7.18,org.springframework.boot:spring-boot-starter-tomcat:2.7.18,org.springframework.boot:spring-boot-starter-json:2.7.18)~~>*/implementation "org.springframework.boot:spring-boot-starter-web"
+                /*~~(commons-collections:commons-collections:2.0)~~>*/implementation "commons-collections:commons-collections:2.0"
+            }
+            """
+          )
         );
     }
 }


### PR DESCRIPTION
- resolves: https://github.com/moderneinc/customer-requests/issues/1456
- `org.openrewrite.dataTables` message values are stored in a `ConcurrentHashMap` and do not preserve order. This can cause `UpgradesAndMigrations.Row`s inserted with versions of dependencies defined in other cards. The `DevCenterTest#devcenterWithMultipleLibraryUpgradeRecipesHasCorrectData` test reproduces this issue. As such I've updated `DataTableWatcher#stop` to return only data table rows added to the `ExecutionContext` since `DataTableWatcher#start` was called