### PR TITLE
Fix race condition in UpgradesAndMigrations.insertRow

### DIFF
--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -66,10 +66,15 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
 
     @Override
     public void insertRow(ExecutionContext ctx, Row row) {
-        Row prev = bestRows.get(row.getCard());
-        Row best = prev == null ? row : bestRow(prev, row);
-        if (best != prev) {
-            bestRows.put(row.getCard(), best);
+        boolean[] improved = {false};
+        bestRows.compute(row.getCard(), (card, prev) -> {
+            Row best = prev == null ? row : bestRow(prev, row);
+            if (best != prev) {
+                improved[0] = true;
+            }
+            return best;
+        });
+        if (improved[0]) {
             super.insertRow(ctx, row);
         }
     }


### PR DESCRIPTION
## Summary

- The `get → compare → put → super.insertRow` sequence on `bestRows` (`ConcurrentHashMap`) was not atomic. When the worker processes source files in parallel, two threads could both read `prev=null` for the same card and both insert, producing duplicate rows and non-deterministic data table output.
- Replaced with `ConcurrentHashMap.compute()` which executes the best-row determination atomically per card key.

- This is part of diagnosing inconsistent `UpgradesAndMigrations` data table results from `DevCenterStarter`. The companion fix for `mergeByClassName` row deduplication is in moderneinc/moderne-worker#1263.

## Test plan

- [x] All 136 existing tests pass