### PR TITLE
Set group on UpgradesAndMigrations DataTable

### DIFF
--- a/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
+++ b/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
@@ -22,7 +22,8 @@ import org.openrewrite.Recipe;
 import java.util.List;
 
 public abstract class UpgradeMigrationCard extends Recipe {
-    protected transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this);
+    protected transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this)
+            .withGroup("io.moderne.devcenter.upgradesAndMigrations");
 
     public abstract List<DevCenterMeasure> getMeasures();
 

--- a/src/test/java/io/moderne/devcenter/UpgradeMigrationCardGroupTest.java
+++ b/src/test/java/io/moderne/devcenter/UpgradeMigrationCardGroupTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.moderne.devcenter;
+
+import io.moderne.devcenter.table.UpgradesAndMigrations;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpgradeMigrationCardGroupTest {
+
+    @Test
+    void multipleCardsShareSameDataTable() {
+        JavaVersionUpgrade javaCard = new JavaVersionUpgrade(25, null);
+        JUnitJupiterUpgrade junitCard = new JUnitJupiterUpgrade();
+        BuildToolCard gradleCard = new BuildToolCard("Upgrade to Gradle 9", "Gradle", "9.0.0", null);
+
+        // In production, the platform sets each DataTable's instance name
+        // from the owning recipe, producing distinct bucket keys per card
+        javaCard.upgradesAndMigrations.withInstanceName(javaCard::getInstanceName);
+        junitCard.upgradesAndMigrations.withInstanceName(junitCard::getInstanceName);
+        gradleCard.upgradesAndMigrations.withInstanceName(gradleCard::getInstanceName);
+
+        InMemoryDataTableStore store = new InMemoryDataTableStore();
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        DataTableExecutionContextView.view(ctx).setDataTableStore(store);
+
+        javaCard.upgradesAndMigrations.insertRow(ctx, new UpgradesAndMigrations.Row(
+                "Move to Java 25", 0, "Java 8+", "8"));
+        junitCard.upgradesAndMigrations.insertRow(ctx, new UpgradesAndMigrations.Row(
+                "Move to JUnit 6", 0, "JUnit 4", "4.13"));
+        gradleCard.upgradesAndMigrations.insertRow(ctx, new UpgradesAndMigrations.Row(
+                "Upgrade to Gradle 9", 0, "Major", "8.5.0"));
+
+        // All three cards wrote to the same bucket because they share a group
+        assertThat(store.getDataTables()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Sets `.withGroup("io.moderne.devcenter.upgradesAndMigrations")` on the `UpgradesAndMigrations` DataTable in `UpgradeMigrationCard` so all card subclasses (JavaVersionUpgrade, JUnitJupiterUpgrade, BuildToolCard, etc.) share a single storage bucket instead of getting separate buckets per recipe instance name.
- Adds a test that creates three different cards, simulates the platform setting distinct instance names, and asserts they all write to one bucket. The test fails without the group.

## Test plan
- [x] `UpgradeMigrationCardGroupTest.multipleCardsShareSameDataTable` passes with group, fails without it (verified both directions)