### PR TITLE
Fix DevCenterTest to query UpgradesAndMigrations by group

### DIFF
--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -273,7 +273,7 @@ class DevCenterTest implements RewriteTest {
           spec ->
             spec.recipeFromYaml(recipe, "io.moderne.devcenter.TwoLibraryUpgrades")
               .beforeRecipe(withToolingApi())
-              .afterRecipe(after -> assertThat(after.getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations"))
+              .afterRecipe(after -> assertThat(after.<UpgradesAndMigrations.Row>getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations", "io.moderne.devcenter.upgradesAndMigrations"))
                 .extracting("card", "ordinal", "value", "currentMinimumVersion")
                 .containsExactly(
                   tuple("Move to Spring Boot 4.0", 0, "Major", "2.7.18"),


### PR DESCRIPTION
## Summary
- Fixes the CI failure introduced by #66 where `DevCenterTest.devcenterWithMultipleLibraryUpgradeRecipesHasCorrectData` was querying with `group=null` but the rows are now stored under the `"io.moderne.devcenter.upgradesAndMigrations"` group key.

## Test plan
- [x] All 137 tests pass locally