### PR TITLE
Set data table groups to FQN for clean filenames

### DIFF
--- a/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
+++ b/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public abstract class UpgradeMigrationCard extends Recipe {
     protected transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this)
-            .withGroup("io.moderne.devcenter.upgradesAndMigrations");
+            .withGroup("io.moderne.devcenter.table.UpgradesAndMigrations");
 
     public abstract List<DevCenterMeasure> getMeasures();
 

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -273,7 +273,7 @@ class DevCenterTest implements RewriteTest {
           spec ->
             spec.recipeFromYaml(recipe, "io.moderne.devcenter.TwoLibraryUpgrades")
               .beforeRecipe(withToolingApi())
-              .afterRecipe(after -> assertThat(after.<UpgradesAndMigrations.Row>getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations", "io.moderne.devcenter.upgradesAndMigrations"))
+              .afterRecipe(after -> assertThat(after.<UpgradesAndMigrations.Row>getDataTableRows("io.moderne.devcenter.table.UpgradesAndMigrations", "io.moderne.devcenter.table.UpgradesAndMigrations"))
                 .extracting("card", "ordinal", "value", "currentMinimumVersion")
                 .containsExactly(
                   tuple("Move to Spring Boot 4.0", 0, "Major", "2.7.18"),


### PR DESCRIPTION
## Summary

Fix `UpgradeMigrationCard` group value that was missing the `.table.` package segment and used camelCase instead of PascalCase.

The group was `"io.moderne.devcenter.upgradesAndMigrations"` but the table's FQN (`DataTable.getName()`) is `"io.moderne.devcenter.table.UpgradesAndMigrations"`. Since `group != name`, `CsvDataTableStore.fileKey()` appends a `--io-moderne-devcenter-04a0` suffix to the CSV filename. This breaks `mod devcenter` and the SaaS worker, which look up data table CSVs by exact FQN.

Setting the group to the actual FQN makes `group == name`, so `fileKey()` returns the plain name with no suffix. Row merging still works — all `UpgradeMigrationCard` subclasses share the same group.

SecurityIssues and OrganizationStatistics are unaffected — they don't set a group, and the `instanceName == displayName` fallback in `fileKey()` already produces clean filenames for them.

## Test plan

- [x] All existing tests pass
- [x] Verified broken: `CsvDataTableStore.fileKey(upgradesAndMigrations)` returned `io.moderne.devcenter.table.UpgradesAndMigrations--io-moderne-devcenter-04a0`
- [x] Verified fixed: returns `io.moderne.devcenter.table.UpgradesAndMigrations` (no suffix)