### PR TITLE
Expose UpgradesAndMigrations.GROUP as a public constant

### DIFF
--- a/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
+++ b/src/main/java/io/moderne/devcenter/UpgradeMigrationCard.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public abstract class UpgradeMigrationCard extends Recipe {
     protected transient UpgradesAndMigrations upgradesAndMigrations = new UpgradesAndMigrations(this)
-            .withGroup("io.moderne.devcenter.upgradesAndMigrations");
+            .withGroup(UpgradesAndMigrations.GROUP);
 
     public abstract List<DevCenterMeasure> getMeasures();
 

--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -31,6 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.openrewrite.ExecutionContext.CURRENT_CYCLE;
 
 public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> {
+    /**
+     * The community group name that all {@link io.moderne.devcenter.UpgradeMigrationCard}
+     * subclasses use to share a single data table bucket. Downstream consumers (the Moderne
+     * CLI and SaaS worker) can reference this constant to compose the on-disk CSV filename
+     * via {@code CsvDataTableStore.fileKey()} without duplicating the literal.
+     */
+    public static final String GROUP = "io.moderne.devcenter.upgradesAndMigrations";
+
     private static final String BEST_ROWS_KEY = UpgradesAndMigrations.class.getName() + ".bestRows";
 
     private Map<String, Row> getBestRows(ExecutionContext ctx) {


### PR DESCRIPTION
## Summary

- Add `public static final String GROUP` to `UpgradesAndMigrations`.
- Switch `UpgradeMigrationCard` to reference the constant instead of duplicating the literal.

## Why

The group name `io.moderne.devcenter.upgradesAndMigrations` is referenced by downstream consumers (moderne-cli's `mod devcenter`, moderne-saas `DevCenterResultAggregator`). Exposing it as a constant lets those consumers import the symbol instead of copy-pasting the string.

The CLI and SaaS fixes for finding group-suffixed CSV files live in companion PRs. Those fixes do not depend on this constant (they read group names from file metadata headers at runtime), but having the constant in rewrite-devcenter is a cleanliness win that makes the intent obvious at the use site.

## Test plan

- [x] `./gradlew compileJava` — passes
- [x] Existing `UpgradeMigrationCardGroupTest` still exercises the shared-bucket behavior via the group
- [x] End-to-end: published locally, installed into Moderne CLI via `./modw config recipes jar install io.moderne.recipe:rewrite-devcenter:LATEST`, ran `mod devcenter` on a commons-lang checkout, verified the grouped `.csv.gz` is produced and the dashboard is populated