### PR TITLE
Fix EPSS measure labels for consistency

### DIFF
--- a/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
+++ b/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
@@ -219,9 +219,9 @@ public class DependencyVulnerabilityCheck extends UpgradeMigrationCard {
     public enum EPSSMeasure implements DevCenterMeasure {
         Critical("Critical", ">50%"),
         High("High", "10-50%"),
-        Medium("Moderate", "1-10%"),
+        Medium("Medium", "1-10%"),
         Low("Low", "<1%"),
-        NotFound("Not available", "No EPSS score available");
+        NotFound("Not found", "No EPSS score available");
 
         private final String name;
         private final String description;


### PR DESCRIPTION
## Summary
- Rename `EPSSMeasure.Medium` label from "Moderate" to "Medium" to match the enum name
- Rename `EPSSMeasure.NotFound` label from "Not available" to "Not found" to match the enum name

## Test plan
- [ ] Verify existing tests pass with updated labels