### PR TITLE
Rename EPSSMeasure.NotFound label to "No vulnerability scores"

### DIFF
--- a/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
+++ b/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
@@ -221,7 +221,7 @@ public class DependencyVulnerabilityCheck extends UpgradeMigrationCard {
         High("High", "10-50%"),
         Medium("Medium", "1-10%"),
         Low("Low", "<1%"),
-        NotFound("Not found", "No EPSS score available");
+        NotFound("No vulnerability scores", "No EPSS score available");
 
         private final String name;
         private final String description;


### PR DESCRIPTION
Updates the `EPSSMeasure.NotFound` label from `"Not found"` to `"No vulnerability scores"` to make the displayed measure name clearer to users.