### PR TITLE
Refresh Apache Maven parent POM versions

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-maven-devcenter.yml
+++ b/src/main/resources/META-INF/rewrite/apache-maven-devcenter.yml
@@ -25,7 +25,7 @@ recipeList:
       cardName: Move to the latest `apache` parent POM
       groupIdPattern: org.apache
       artifactIdPattern: apache
-      version: 35
+      version: 37
       upgradeRecipe: io.moderne.devcenter.UpgradeApacheParent
   - io.moderne.devcenter.JavaVersionUpgrade:
       majorVersion: 25
@@ -47,19 +47,19 @@ recipeList:
       cardName: Move to the latest `maven-parent`
       groupIdPattern: org.apache.maven
       artifactIdPattern: maven-parent
-      version: 45
+      version: 47
       upgradeRecipe: io.moderne.devcenter.UpgradeMavenParent
   - io.moderne.devcenter.ParentPomUpgrade:
       cardName: Move to the latest `maven-plugins`
       groupIdPattern: org.apache.maven.plugins
       artifactIdPattern: maven-plugins
-      version: 45
+      version: 47
       upgradeRecipe: io.moderne.devcenter.UpgradeMavenPluginsParent
   - io.moderne.devcenter.ParentPomUpgrade:
       cardName: Move to the latest `maven-shared-components`
       groupIdPattern: org.apache.maven.shared
       artifactIdPattern: maven-shared-components
-      version: 45
+      version: 47
       upgradeRecipe: io.moderne.devcenter.UpgradeMavenSharedParent
   - io.moderne.devcenter.JavaVersionUpgrade:
       majorVersion: 17


### PR DESCRIPTION
## Summary
Bumps the parent POM versions tracked in `apache-maven-devcenter.yml` to the latest Maven Central releases: `org.apache:apache` 35→37, and `maven-parent`/`maven-plugins`/`maven-shared-components` 45→47.

## Test plan
- [ ] CI passes