### PR TITLE
Add `DevCenter.getSpec()` returning a versioned JSON description

### DIFF
--- a/src/main/java/io/moderne/devcenter/DevCenter.java
+++ b/src/main/java/io/moderne/devcenter/DevCenter.java
@@ -15,6 +15,8 @@
  */
 package io.moderne.devcenter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.moderne.devcenter.table.SecurityIssues;
 import io.moderne.devcenter.table.UpgradesAndMigrations;
 import lombok.EqualsAndHashCode;
@@ -29,6 +31,7 @@ import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -120,6 +123,55 @@ public class DevCenter {
             }
         }
         throw new IllegalArgumentException("No card found with name: " + name);
+    }
+
+    /**
+     * Returns a stable JSON description of this DevCenter's structure for
+     * cross-classloader consumption by tools (e.g. the Moderne CLI). The
+     * format carries an {@code apiVersion} so consumers can detect schema
+     * compatibility. Schema (v1):
+     * <pre>{@code
+     * {
+     *   "apiVersion": "v1",
+     *   "upgradesAndMigrations": [
+     *     {"name": "...", "fixRecipeId": "...", "measures": ["...", ...]},
+     *     ...
+     *   ],
+     *   "security": {"name": "...", "fixRecipeId": "...", "measures": [...]} | null
+     * }
+     * }</pre>
+     * Card and measure ordering is preserved.
+     */
+    public String getSpec() {
+        Map<String, Object> spec = new LinkedHashMap<>();
+        spec.put("apiVersion", "v1");
+
+        List<Map<String, Object>> upgrades = new ArrayList<>();
+        for (Card card : getUpgradesAndMigrations()) {
+            upgrades.add(cardToSpec(card));
+        }
+        spec.put("upgradesAndMigrations", upgrades);
+
+        Card securityCard = getSecurity();
+        spec.put("security", securityCard == null ? null : cardToSpec(securityCard));
+
+        try {
+            return new ObjectMapper().writeValueAsString(spec);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize DevCenter spec", e);
+        }
+    }
+
+    private static Map<String, Object> cardToSpec(Card card) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", card.getName());
+        map.put("fixRecipeId", card.getFixRecipeId());
+        List<String> measureNames = new ArrayList<>();
+        for (DevCenterMeasure m : card.getMeasures()) {
+            measureNames.add(m.getName());
+        }
+        map.put("measures", measureNames);
+        return map;
     }
 
     private List<Card> getUpgradesAndMigrationsRecursive(Recipe recipe, List<Card> upgradesAndMigrations) {

--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -15,6 +15,8 @@
  */
 package io.moderne.devcenter;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.siegmar.fastcsv.reader.CommentStrategy;
 import de.siegmar.fastcsv.reader.CsvReader;
 import de.siegmar.fastcsv.reader.NamedCsvRecord;
@@ -41,6 +43,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -130,6 +133,55 @@ class DevCenterTest implements RewriteTest {
     void validateStandAloneDevCenterRecipe() throws Exception {
         var devCenter = new DevCenter(starterSecurity);
         devCenter.validate();
+    }
+
+    @Test
+    void getSpecMatchesStarterDevCenter() throws Exception {
+        var devCenter = new DevCenter(starterDevCenter);
+        JsonNode spec = new ObjectMapper().readTree(devCenter.getSpec());
+
+        assertThat(spec.get("apiVersion").asText()).isEqualTo("v1");
+
+        JsonNode upgrades = spec.get("upgradesAndMigrations");
+        assertThat(upgrades.isArray()).isTrue();
+        assertThat(upgrades.size()).isEqualTo(3);
+
+        JsonNode firstCard = upgrades.get(0);
+        assertThat(firstCard.get("name").asText()).isEqualTo(devCenter.getUpgradesAndMigrations().getFirst().getName());
+        List<String> measureNames = new ArrayList<>();
+        firstCard.get("measures").forEach(m -> measureNames.add(m.asText()));
+        assertThat(measureNames).containsExactly("Major", "Minor", "Patch", "Completed");
+
+        JsonNode security = spec.get("security");
+        assertThat(security.isNull()).isFalse();
+        assertThat(security.get("name").asText()).isEqualTo(devCenter.getSecurity().getName());
+        List<String> securityMeasures = new ArrayList<>();
+        security.get("measures").forEach(m -> securityMeasures.add(m.asText()));
+        assertThat(securityMeasures).contains("Zip slip");
+    }
+
+    @Test
+    void getSpecOmitsSecurityWhenAbsent() throws Exception {
+        //language=yaml
+        var recipe = """
+          type: specs.openrewrite.org/v1beta/recipe
+          name: io.moderne.devcenter.JavaOnly
+          displayName: Just an upgrade card
+          description: Upgrade Java version
+          recipeList:
+            - io.moderne.devcenter.JavaVersionUpgrade:
+                majorVersion: 21
+          """;
+        Recipe r = Environment.builder()
+          .load(new YamlResourceLoader(new ByteArrayInputStream(recipe.getBytes(StandardCharsets.UTF_8)),
+            URI.create("rewrite.yml"), new Properties()))
+          .build()
+          .activateRecipes("io.moderne.devcenter.JavaOnly");
+
+        JsonNode spec = new ObjectMapper().readTree(new DevCenter(r).getSpec());
+        assertThat(spec.get("apiVersion").asText()).isEqualTo("v1");
+        assertThat(spec.get("upgradesAndMigrations").size()).isEqualTo(1);
+        assertThat(spec.get("security").isNull()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `String getSpec()` to `io.moderne.devcenter.DevCenter`, returning a versioned JSON description of the devcenter's cards and measures.
- Lets consumers (the Moderne CLI) read DevCenter structure without sharing Java class identity across classloaders. The CLI today bundles this artifact in its fat jar to wire `DevCenter` into parent classpath; that bundling causes class-identity splits and shadows customer-provided `rewrite-devcenter` versions. JSON-over-reflection is the contract that lets the CLI unbundle.

## Schema (v1)

```json
{
  "apiVersion": "v1",
  "upgradesAndMigrations": [
    {"name": "...", "fixRecipeId": "...", "measures": ["...", ...]},
    ...
  ],
  "security": {"name": "...", "fixRecipeId": "...", "measures": [...]} | null
}
```

Card and measure ordering is preserved. `fixRecipeId` may be null. `security` is null when no security card is defined.

## Test plan

- [x] `getSpecMatchesStarterDevCenter` — full structure round-trip against `DevCenterStarter`, including security card + measure ordering
- [x] `getSpecOmitsSecurityWhenAbsent` — nullable security handling
- [x] `./gradlew compileJava` passes

## Follow-up

The Moderne CLI side that consumes `getSpec()` is a separate PR in `moderne-cli` (depends on this artifact being released).