### PR TITLE
Fix DevCenterTest compile error from invalid type witness

### DIFF
--- a/src/test/java/io/moderne/devcenter/DevCenterTest.java
+++ b/src/test/java/io/moderne/devcenter/DevCenterTest.java
@@ -284,7 +284,7 @@ class DevCenterTest implements RewriteTest {
             }
         };
 
-        var recipeClass = isolatedClassLoader.<?>loadClass("io.moderne.devcenter.JavaVersionUpgrade");
+        Class<?> recipeClass = isolatedClassLoader.loadClass("io.moderne.devcenter.JavaVersionUpgrade");
         var recipe = (Recipe) recipeClass.getConstructor(int.class, String.class)
           .newInstance(21, "org.openrewrite.java.migrate.Java21");
 


### PR DESCRIPTION
## Summary
- Main has been red since 7986ed6 ([CI run](https://github.com/moderneinc/rewrite-devcenter/actions/runs/25959656593/job/76312696647)).
- The OpenRewrite best practices recipe rewrote `Class<?> recipeClass = isolatedClassLoader.loadClass(...)` to `var recipeClass = isolatedClassLoader.<?>loadClass(...)`, which is invalid Java (`<?>` is not a valid type witness).
- Reverted that one line to the explicit `Class<?>` form; can't keep `var` here because `loadClass` returns the raw `Class`, so `var` would infer the raw type and lose the wildcard.

## Test plan
- [x] `./gradlew compileTestJava` succeeds locally
- [ ] CI green on this PR