### PR TITLE
Force opennlp-tools 2.5.9 to fix critical CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,15 @@ recipeDependencies {
     testParserClasspath("org.junit.jupiter:junit-jupiter-api:6.0.2")
 }
 
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.apache.opennlp" && requested.name == "opennlp-tools") {
+            useVersion("2.5.9")
+            because("CVE-2026-42027, CVE-2026-40682, CVE-2026-42440")
+        }
+    }
+}
+
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))


### PR DESCRIPTION
## Summary
- Force `opennlp-tools` to 2.5.9 via `resolutionStrategy` to address three critical Apache OpenNLP vulnerabilities
- CVE-2026-42027: Arbitrary Class Instantiation via Model Manifest (CRITICAL)
- CVE-2026-40682: XML External Entity (XXE) via Dictionary Parsing (CRITICAL)  
- CVE-2026-42440: OOM Denial of Service via Unbounded Array Allocation (HIGH)

Matches the existing pattern in `rewrite-prethink`.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1073

## Test plan
- [ ] CI passes
- [ ] `./gradlew dependencyCheckAggregate` no longer flags opennlp-tools CVEs