### PR TITLE
Avoid duplicate UpgradesAndMigrations rows per repo and card

### DIFF
--- a/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
+++ b/src/main/java/io/moderne/devcenter/table/UpgradesAndMigrations.java
@@ -96,8 +96,12 @@ public class UpgradesAndMigrations extends DataTable<UpgradesAndMigrations.Row> 
     public void insertRow(ExecutionContext ctx, Row row) {
         boolean[] improved = {false};
         getBestRows(ctx).compute(row.getCard(), (card, prev) -> {
-            Row best = prev == null ? row : bestRow(prev, row);
-            if (best != prev) {
+            if (prev == null) {
+                improved[0] = true;
+                return row;
+            }
+            Row best = bestRow(prev, row);
+            if (best != prev && best.getOrdinal() < prev.getOrdinal()) {
                 improved[0] = true;
             }
             return best;

--- a/src/test/java/io/moderne/devcenter/result/DevCenterResultReducerTest.java
+++ b/src/test/java/io/moderne/devcenter/result/DevCenterResultReducerTest.java
@@ -75,6 +75,27 @@ class DevCenterResultReducerTest {
     }
 
     @Test
+    void duplicateRowsForOneRepoCountAsOneRepo() {
+        DevCenterResultReducer reducer = DevCenterResultReducer.fromDataTables(
+          devCenter,
+          root,
+          new StringReader("""
+            repositoryOrigin,repositoryPath,repositoryBranch,card,ordinal,value,currentMinimumVersion
+            github.com,finos/spring-bot,spring-bot-master,Move to Spring Boot 4.0,0,Major,3.5.0
+            github.com,finos/spring-bot,spring-bot-master,Move to Spring Boot 4.0,0,Major,3.4.0
+            """),
+          new StringReader("")
+        );
+
+        reducer.reduce(root).forEach(
+          devCenter.getCard("Move to Spring Boot 4.0"),
+          (measure, count) -> {
+              assertThat(measure).isEqualTo(SemverMeasure.Major);
+              assertThat(count).isEqualTo(1);
+          });
+    }
+
+    @Test
     void emptySecurity() {
         DevCenterResultReducer reducer = DevCenterResultReducer.fromDataTables(
           devCenter,

--- a/src/test/java/io/moderne/devcenter/table/UpgradesAndMigrationsTest.java
+++ b/src/test/java/io/moderne/devcenter/table/UpgradesAndMigrationsTest.java
@@ -15,6 +15,7 @@
  */
 package io.moderne.devcenter.table;
 
+import io.moderne.devcenter.LibraryUpgrade;
 import io.moderne.devcenter.ParentPomUpgrade;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
@@ -23,6 +24,7 @@ import java.nio.file.Path;
 
 import static io.moderne.devcenter.SemverMeasure.Major;
 import static io.moderne.devcenter.SemverMeasure.Minor;
+import static io.moderne.devcenter.SemverMeasure.Patch;
 import static io.moderne.devcenter.table.UpgradesAndMigrations.bestRow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -60,6 +62,25 @@ class UpgradesAndMigrationsTest implements RewriteTest {
     }
 
     @Test
+    void singleRowAtSameOrdinalRegardlessOfOrder() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new LibraryUpgrade("Spring Boot",
+              "org.springframework.boot", "*", "3.4.5", null))
+            .dataTable(UpgradesAndMigrations.Row.class, rows -> {
+                assertThat(rows).hasSize(3);
+                assertThat(rows)
+                  .extracting(UpgradesAndMigrations.Row::getOrdinal)
+                  .containsExactlyInAnyOrder(
+                    Patch.ordinal(), Minor.ordinal(), Major.ordinal());
+            }),
+          pomXml(pairPom("3.4.3", "3.4.2"), spec -> spec.path(Path.of("patch-pair/pom.xml"))),
+          pomXml(pairPom("3.2.0", "3.1.0"), spec -> spec.path(Path.of("minor-pair/pom.xml"))),
+          pomXml(pairPom("2.5.0", "2.4.0"), spec -> spec.path(Path.of("major-pair/pom.xml")))
+        );
+    }
+
+    @Test
     void nullVersionDoesNotCauseNpe() {
         var nullVersion = new UpgradesAndMigrations.Row("card", Minor.ordinal(), "Minor", null);
         var withVersion = new UpgradesAndMigrations.Row("card", Minor.ordinal(), "Minor", "2.2.0");
@@ -80,6 +101,28 @@ class UpgradesAndMigrationsTest implements RewriteTest {
             </parent>
           </project>
           """.formatted(version);
+    }
+
+    private static String pairPom(String firstVersion, String secondVersion) {
+        return """
+          <project>
+            <groupId>com.example</groupId>
+            <artifactId>example</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>%s</version>
+              </dependency>
+              <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter</artifactId>
+                <version>%s</version>
+              </dependency>
+            </dependencies>
+          </project>
+          """.formatted(firstVersion, secondVersion);
     }
 
 }


### PR DESCRIPTION
## Summary

An `UpgradeMigrationCard` recipe (e.g. `LibraryUpgrade` with a broad `artifactIdPattern`) could append more than one row to the `UpgradesAndMigrations` data table for the same repository and card. When two matching dependencies landed at the same ordinal but at different versions, the in-memory `bestRows` map would swap to the lower version and `insertRow` would re-write — but the underlying data table is append-only, so the earlier row was left behind. Downstream consumers that count CSV rows (rather than grouping by repository) then over-reported the affected repo, surfacing as inflated "X repos" counts on the corresponding DevCenter card.

`insertRow` now only writes to the data table when the ordinal strictly improves over the previously persisted row. Same-ordinal updates still keep the in-memory best entry in sync but no longer append a stale duplicate row. As a tradeoff, the persisted `currentMinimumVersion` at a given ordinal is the first version seen at that ordinal rather than the absolute lowest, which is acceptable for the per-card-per-repo semantics the table is meant to represent.