### PR TITLE
Fix DependencyVulnerabilityCheck per-tree Accumulator leak on root cursor

### DIFF
--- a/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
+++ b/src/main/java/io/moderne/devcenter/DependencyVulnerabilityCheck.java
@@ -77,7 +77,12 @@ public class DependencyVulnerabilityCheck extends UpgradeMigrationCard {
             @Override
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
-                DependencyVulnerabilityCheckBase.Accumulator acc = scan.getAccumulator(getCursor(), ctx);
+                // Build the accumulator as a local. scan.getAccumulator(...) would pin it on the
+                // shared per-cycle root cursor under a fresh UUID key (scan is reconstructed for
+                // every getVisitor() call, so the key is never the same twice), leaving one
+                // vulnerability-DB-bearing Accumulator stranded on the root cursor for every
+                // Maven/Gradle build file visited. On multi-module repos that grows to GBs.
+                DependencyVulnerabilityCheckBase.Accumulator acc = scan.getInitialValue(ctx);
                 try {
                     scan.getScanner(acc).visitNonNull(tree, ctx);
                 } catch (Exception e) {

--- a/src/test/java/io/moderne/devcenter/DependencyVulnerabilityCheckLeakTest.java
+++ b/src/test/java/io/moderne/devcenter/DependencyVulnerabilityCheckLeakTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.moderne.devcenter;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.RecipeScheduler;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.InMemoryLargeSourceSet;
+import org.openrewrite.maven.MavenParser;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards against re-introducing the per-source-file accumulator leak in
+ * {@link DependencyVulnerabilityCheck}. The inner
+ * {@code org.openrewrite.java.dependencies.DependencyVulnerabilityCheck} extends
+ * {@code ScanningRecipe}, which keys its accumulator on a fresh UUID per
+ * instance. Because that scan was reconstructed for every {@code getVisitor()}
+ * call (i.e. every Maven/Gradle file), routing through
+ * {@code ScanningRecipe.getAccumulator(...)} would pin a separate ~MB-scale
+ * Accumulator (vulnerability DB + per-project dependency paths) onto the
+ * shared per-cycle root cursor for every build file. Multi-module repos like
+ * spring-projects/spring-framework reach GBs that way and OOM the CLI.
+ */
+class DependencyVulnerabilityCheckLeakTest {
+
+    @Test
+    void accumulatorDoesNotLeakOntoRootCursorPerSourceFile() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        List<SourceFile> sources = parsePoms(8);
+
+        AtomicReference<KeyRecordingCursor> rootRef = new AtomicReference<>();
+        new RecipeScheduler()
+                .rootCursorProvider(() -> {
+                    KeyRecordingCursor c = new KeyRecordingCursor();
+                    rootRef.set(c);
+                    return c;
+                })
+                .scheduleRun(
+                        new DependencyVulnerabilityCheck(true, true, "Severity"),
+                        new InMemoryLargeSourceSet(sources),
+                        ctx,
+                        1,
+                        1
+                );
+
+        KeyRecordingCursor root = rootRef.get();
+        assertThat(root).isNotNull();
+
+        // Any keys recorded under the ScanningRecipe accumulator prefix point at the leak:
+        // each source file would deposit one Accumulator under a fresh UUID-based key.
+        Set<String> accumulatorKeys = root.keys.stream()
+                .filter(k -> k.startsWith("org.openrewrite.recipe.acc."))
+                .collect(Collectors.toSet());
+
+        assertThat(accumulatorKeys)
+                .as("DependencyVulnerabilityCheck must not pin a per-tree Accumulator on the shared root cursor; otherwise multi-module Maven/Gradle repos accumulate GBs of vulnerability-DB-bearing state and OOM")
+                .isEmpty();
+    }
+
+    private static List<SourceFile> parsePoms(int count) {
+        Function<Integer, String> pom = i -> "<project>\n" +
+                "  <groupId>com.example</groupId>\n" +
+                "  <artifactId>example-" + i + "</artifactId>\n" +
+                "  <version>1.0-SNAPSHOT</version>\n" +
+                "  <dependencies>\n" +
+                "    <dependency>\n" +
+                "      <groupId>org.springframework</groupId>\n" +
+                "      <artifactId>spring-web</artifactId>\n" +
+                "      <version>6.2.7</version>\n" +
+                "    </dependency>\n" +
+                "  </dependencies>\n" +
+                "</project>\n";
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        List<SourceFile> all = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            String text = pom.apply(i);
+            MavenParser.builder().build()
+                    .parse(ctx, text)
+                    .forEach(s -> all.add(s.withSourcePath(
+                            java.nio.file.Paths.get("module-" + all.size() + "/pom.xml")
+                    )));
+        }
+        return all;
+    }
+
+    /**
+     * Records every key ever passed to {@link #computeMessageIfAbsent} on the
+     * <em>root</em> cursor across a single recipe cycle. The framework calls
+     * {@code cursor.getRoot().computeMessageIfAbsent(...)}, and {@code getRoot()}
+     * walks the parent chain to whichever Cursor it was rooted at - this one.
+     */
+    private static class KeyRecordingCursor extends Cursor {
+        final Set<String> keys = new HashSet<>();
+
+        KeyRecordingCursor() {
+            super(null, Cursor.ROOT_VALUE);
+        }
+
+        @Override
+        public <T> T computeMessageIfAbsent(String key, java.util.function.Function<String, ? extends T> mappingFunction) {
+            keys.add(key);
+            return super.computeMessageIfAbsent(key, mappingFunction);
+        }
+
+        @Override
+        public void putMessage(String key, Object value) {
+            keys.add(key);
+            super.putMessage(key, value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix a per-source-file `Accumulator` leak in `DependencyVulnerabilityCheck` that strands one vulnerability-DB-bearing accumulator on the shared per-cycle root cursor for every Maven/Gradle build file visited. Multi-module repos like spring-projects/spring-framework compound this into GBs and OOM the CLI (`moderneinc/moderne-saas#836`).
- The DevCenter starter wraps the DVC card three times (Severity / UpgradeDelta / RiskScore), so the leak multiplies per cycle.

## Root cause
`getVisitor()` constructs a fresh inner `org.openrewrite.java.dependencies.DependencyVulnerabilityCheck scan` every time the framework calls it — i.e. once per source file. That inner recipe extends `ScanningRecipe`, which keys its accumulator on `recipeAccMessage = "org.openrewrite.recipe.acc." + UUID.randomUUID()` — a fresh UUID per instance. The card's `preVisit` then went through `scan.getAccumulator(getCursor(), ctx)`, whose body is:

```java
return cursor.getRoot().computeMessageIfAbsent(getRecipeAccMessage(), m -> getInitialValue(ctx));
```

`getRoot()` walks to the per-cycle root cursor that `RecipeRunCycle.editSource` propagates via `visitor.setCursor(rootCursor)`. Because the UUID key is new on every visit, each Maven/Gradle file deposits a brand-new `Accumulator` (vulnerability DB + per-project `ResolvedDependency` paths + repositories + version-lookup maps) under a different key, with no way to reuse or release it until the cycle ends.

## Fix
Build the accumulator as a local with `scan.getInitialValue(ctx)`. We consume it entirely inside `preVisit` (read `scan.vulnerabilities(acc)` and insert rows immediately), so cursor lifetime is the wrong scope — a local is correct and becomes GC-eligible when `preVisit` returns.

## Test plan
- [x] `./gradlew test` — existing `DependencyVulnerabilityCheckTest` cases still pass.
- [x] New `DependencyVulnerabilityCheckLeakTest` drives the recipe via `RecipeScheduler` with a custom `rootCursorProvider` returning a `KeyRecordingCursor` that intercepts `computeMessageIfAbsent`/`putMessage`. Asserts no `org.openrewrite.recipe.acc.*` keys remain after running across 8 distinct POMs.
- [x] Inverse check: reverting the one-line fix makes the new test fail with exactly 8 leaked UUID keys (one per parsed POM); reapplying the fix makes it pass.
