### PR TITLE
Add example recipe IDs to upgradeRecipe options on version-upgrade cards

### DIFF
--- a/src/main/java/io/moderne/devcenter/AngularVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/AngularVersionUpgrade.java
@@ -48,6 +48,7 @@ public class AngularVersionUpgrade extends UpgradeMigrationCard {
 
     @Option(displayName = "Upgrade recipe",
             description = "The recipe to use to upgrade.",
+            example = "org.openrewrite.codemods.migrate.angular.ApplyAngularCLI",
             required = false)
     @Nullable
     String upgradeRecipe;

--- a/src/main/java/io/moderne/devcenter/CSharpVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/CSharpVersionUpgrade.java
@@ -50,6 +50,7 @@ public class CSharpVersionUpgrade extends UpgradeMigrationCard {
 
     @Option(displayName = "Upgrade recipe",
         description = "The recipe to use to upgrade.",
+        example = "org.openrewrite.dotnet.UpgradeToNet9",
         required = false)
     @Nullable
     String upgradeRecipe;

--- a/src/main/java/io/moderne/devcenter/NodeVersionUpgrade.java
+++ b/src/main/java/io/moderne/devcenter/NodeVersionUpgrade.java
@@ -48,6 +48,7 @@ public class NodeVersionUpgrade extends UpgradeMigrationCard {
 
     @Option(displayName = "Upgrade recipe",
         description = "The recipe to use to upgrade.",
+        example = "org.openrewrite.node.migrate.upgrade-node-22",
         required = false)
     @Nullable
     String upgradeRecipe;


### PR DESCRIPTION
Adds `example` recipe IDs to the optional `upgradeRecipe` `@Option` on three DevCenter version-upgrade cards, so the recipe catalog shows a concrete fix recipe for each. Each example references a real published recipe and aligns with the card's target version: Angular uses `org.openrewrite.codemods.migrate.angular.ApplyAngularCLI`, .NET uses `org.openrewrite.dotnet.UpgradeToNet9` (matches `majorVersion: 9`), and Node.js uses `org.openrewrite.node.migrate.upgrade-node-22` (matches `majorVersion: 22`). Groovy was intentionally left unchanged since no Groovy language-version upgrade recipe exists in the catalog.
