### PR TITLE
Add upgradeRecipe call to action to language DevCenters

### DIFF
--- a/src/main/resources/META-INF/rewrite/angular-devcenter.yml
+++ b/src/main/resources/META-INF/rewrite/angular-devcenter.yml
@@ -24,5 +24,6 @@ description: >-
 recipeList:
   - io.moderne.devcenter.AngularVersionUpgrade:
       majorVersion: 21
+      upgradeRecipe: org.openrewrite.angular.UpgradeToAngular21
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters

--- a/src/main/resources/META-INF/rewrite/csharp-devcenter.yml
+++ b/src/main/resources/META-INF/rewrite/csharp-devcenter.yml
@@ -24,5 +24,6 @@ description: >-
 recipeList:
   - io.moderne.devcenter.CSharpVersionUpgrade:
       majorVersion: 10
+      upgradeRecipe: OpenRewrite.Recipes.CSharp.Migration.Dotnet.Net10.UpgradeToDotNet10
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters

--- a/src/main/resources/META-INF/rewrite/node-devcenter.yml
+++ b/src/main/resources/META-INF/rewrite/node-devcenter.yml
@@ -23,6 +23,7 @@ description: >-
   Track Node.js version adoption across your organization.
 recipeList:
   - io.moderne.devcenter.NodeVersionUpgrade:
-      majorVersion: 22
+      majorVersion: 24
+      upgradeRecipe: org.openrewrite.node.migrate.upgrade-node-24
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters

--- a/src/main/resources/META-INF/rewrite/python-devcenter.yml
+++ b/src/main/resources/META-INF/rewrite/python-devcenter.yml
@@ -23,6 +23,7 @@ description: >-
   Track Python version adoption across your organization.
 recipeList:
   - io.moderne.devcenter.PythonVersionUpgrade:
-      minorVersion: 13
+      minorVersion: 14
+      upgradeRecipe: org.openrewrite.python.migrate.UpgradeToPython314
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters


### PR DESCRIPTION
Adds an `upgradeRecipe` call-to-action to the Angular, C#, Node.js, and Python starter DevCenter version-upgrade cards, which previously tracked versions without pointing at a recipe to perform the upgrade. The Node.js card is bumped to 24 and the Python card to 3.14 to target the latest releases, while Angular (21) and C# (10) keep their current target versions.
